### PR TITLE
Use Pair type; add AccountReader and API tweaks

### DIFF
--- a/pkg/data/ingestors/market/perp/realtime/funding_extension.go
+++ b/pkg/data/ingestors/market/perp/realtime/funding_extension.go
@@ -76,7 +76,7 @@ func (f *FundingRateExtension) ProcessChannels(wsConn interface{}, exchangeName 
 }
 func (f *FundingRateExtension) handleFundingRateUpdate(exchangeName connector.ExchangeName, update perpConn.FundingRate) {
 	// Get asset from the funding rate update
-	asset := update.Asset
+	asset := update.Pair
 
 	// Store the funding rate update
 	f.store.UpdateFundingRate(asset, exchangeName, update)

--- a/pkg/types/connector/perp/capabilities.go
+++ b/pkg/types/connector/perp/capabilities.go
@@ -5,11 +5,15 @@ import (
 	"github.com/wisp-trading/sdk/pkg/types/portfolio"
 )
 
+type AccountReader interface {
+	GetMarginBalances() ([]AssetBalance, error)
+}
+
 // FundingRateProvider handles funding rate data (perps only)
 type FundingRateProvider interface {
 	FetchCurrentFundingRates() (map[portfolio.Pair]FundingRate, error)
-	FetchFundingRate(asset portfolio.Pair) (*FundingRate, error)
-	FetchHistoricalFundingRates(asset portfolio.Pair, startTime, endTime int64) ([]HistoricalFundingRate, error)
+	FetchFundingRate(pair portfolio.Pair) (*FundingRate, error)
+	FetchHistoricalFundingRates(pair portfolio.Pair, startTime, endTime int64) ([]HistoricalFundingRate, error)
 }
 
 // PositionManager handles leveraged positions (perps only)

--- a/pkg/types/connector/perp/connector.go
+++ b/pkg/types/connector/perp/connector.go
@@ -14,6 +14,7 @@ type Connector interface {
 	FundingRateProvider
 	PositionManager
 	ContractProvider
+	AccountReader
 
 	// Perp-specific
 	GetPerpSymbol(symbol portfolio.Pair) string

--- a/pkg/types/connector/perp/funding.go
+++ b/pkg/types/connector/perp/funding.go
@@ -8,7 +8,7 @@ import (
 )
 
 type FundingRate struct {
-	Asset           portfolio.Pair
+	Pair            portfolio.Pair
 	CurrentRate     numerical.Decimal
 	NextFundingTime time.Time
 	Timestamp       time.Time

--- a/pkg/types/connector/perp/position.go
+++ b/pkg/types/connector/perp/position.go
@@ -10,7 +10,7 @@ import (
 
 // Position represents a trading position.
 type Position struct {
-	Symbol           portfolio.Pair         `json:"symbol"`
+	Pair             portfolio.Pair         `json:"symbol"`
 	Exchange         connector.ExchangeName `json:"exchange"`
 	Side             connector.OrderSide    `json:"side"`
 	Size             numerical.Decimal      `json:"size"`

--- a/pkg/types/connector/perp/websocket.go
+++ b/pkg/types/connector/perp/websocket.go
@@ -11,18 +11,18 @@ type WebSocketConnector interface {
 	connector.WebSocketCapable
 
 	// Subscription management
-	SubscribeOrderBook(asset portfolio.Pair) error
-	SubscribeTrades(asset portfolio.Pair) error
-	SubscribePositions(asset portfolio.Pair) error
-	SubscribeFundingRates(asset portfolio.Pair) error
-	SubscribeKlines(asset portfolio.Pair, interval string) error
+	SubscribeOrderBook(pair portfolio.Pair) error
+	SubscribeTrades(pair portfolio.Pair) error
+	SubscribePositions(pair portfolio.Pair) error
+	SubscribeFundingRates(pair portfolio.Pair) error
+	SubscribeKlines(pair portfolio.Pair, interval string) error
 	SubscribeAccountBalance() error
 
-	UnsubscribeOrderBook(asset portfolio.Pair) error
-	UnsubscribeTrades(asset portfolio.Pair) error
-	UnsubscribePositions(asset portfolio.Pair) error
-	UnsubscribeFundingRates(asset portfolio.Pair) error
-	UnsubscribeKlines(asset portfolio.Pair, interval string) error
+	UnsubscribeOrderBook(pair portfolio.Pair) error
+	UnsubscribeTrades(pair portfolio.Pair) error
+	UnsubscribePositions(pair portfolio.Pair) error
+	UnsubscribeFundingRates(pair portfolio.Pair) error
+	UnsubscribeKlines(pair portfolio.Pair, interval string) error
 	UnsubscribeAccountBalance() error
 
 	// Data access channels
@@ -31,5 +31,5 @@ type WebSocketConnector interface {
 	TradeUpdates() <-chan connector.Trade
 	PositionUpdates() <-chan Position
 	FundingRateUpdates() <-chan FundingRate
-	AssetBalanceUpdates() <-chan connector.AssetBalance
+	//AssetBalanceUpdates() <-chan AssetBalance
 }

--- a/pkg/types/connector/spot/connector.go
+++ b/pkg/types/connector/spot/connector.go
@@ -2,6 +2,7 @@ package spot
 
 import (
 	"github.com/wisp-trading/sdk/pkg/types/connector"
+	"github.com/wisp-trading/sdk/pkg/types/portfolio"
 )
 
 // Connector represents a spot market exchange connection
@@ -10,4 +11,6 @@ type Connector interface {
 	connector.MarketDataReader
 	connector.OrderExecutor
 	connector.AccountReader
+
+	GetSpotSymbol(symbol portfolio.Pair) string
 }

--- a/pkg/types/connector/trading.go
+++ b/pkg/types/connector/trading.go
@@ -99,9 +99,11 @@ type Order struct {
 
 // CancelResponse represents the response after canceling an order.
 type CancelResponse struct {
-	OrderID       string      `json:"order_id"`
-	ClientOrderID string      `json:"client_order_id,omitempty"`
-	Symbol        string      `json:"symbol"`
-	Status        OrderStatus `json:"status"`
-	Timestamp     time.Time   `json:"timestamp"`
+	OrderID       string `json:"order_id"`
+	ClientOrderID string `json:"client_order_id,omitempty"`
+	// Deprecated: use Pair instead
+	Symbol    string         `json:"symbol"`
+	Pair      portfolio.Pair `json:"pair"`
+	Status    OrderStatus    `json:"status"`
+	Timestamp time.Time      `json:"timestamp"`
 }


### PR DESCRIPTION
Resolves: https://github.com/wisp-trading/sdk/issues/3

Standardize naming by replacing Asset/Symbol parameters and struct fields with Pair (portfolio.Pair) across perp and websocket types, and update realtime funding handler to use update.Pair. Add an AccountReader interface (GetMarginBalances) and include it in the perp Connector. Add GetSpotSymbol to the spot connector. Update CancelResponse to include a Pair field and mark Symbol as deprecated. These changes unify pair handling across connectors and introduce margin-account reading; downstream connector implementations will need updates to match the revised method signatures and structs.