### PR TITLE
feat: add market filtering to Markets() discovery

### DIFF
--- a/pkg/markets/prediction/predict/predict.go
+++ b/pkg/markets/prediction/predict/predict.go
@@ -86,9 +86,20 @@ func (p predict) WatchMarket(exchange connector.ExchangeName, market predictionc
 	p.predictionWatchlist.RequireMarket(exchange, market)
 }
 
-func (p predict) Markets() []predictionconnector.Market {
-	//TODO implement me
-	panic("implement me")
+func (p predict) Markets(exchange connector.ExchangeName, filter *predictionconnector.MarketsFilter) ([]predictionconnector.Market, error) {
+	marketConnector, exists := p.connectorRegistry.Prediction(exchange)
+
+	if !exists {
+		return nil, errors.New("connector not found for exchange: " + string(exchange))
+	}
+
+	markets, err := marketConnector.Markets(filter)
+
+	if err != nil {
+		return nil, errors.New("failed to fetch markets from exchange: " + string(exchange) + " error: " + err.Error())
+	}
+
+	return markets, nil
 }
 
 func (p predict) Orderbook(exchange connector.ExchangeName, market predictionconnector.Market, outcome predictionconnector.Outcome) (*connector.OrderBook, error) {

--- a/pkg/markets/prediction/types/connector/connector.go
+++ b/pkg/markets/prediction/types/connector/connector.go
@@ -4,6 +4,16 @@ import (
 	"github.com/wisp-trading/sdk/pkg/types/connector"
 )
 
+// MarketsFilter specifies criteria for filtering markets returned by Markets().
+type MarketsFilter struct {
+	// MinVolume filters markets by minimum 24h volume (e.g., "1000.00")
+	MinVolume string
+	// MinLiquidity filters markets by minimum liquidity (e.g., "100.00")
+	MinLiquidity string
+	// Active filters to only active markets (default: true)
+	Active *bool
+}
+
 // Connector represents a prediction market exchange connection
 // Follows the same pattern as spot.Connector and perp.Connector
 // Uses standard connector.OrderExecutor and connector.AccountReader for trading
@@ -17,4 +27,8 @@ type Connector interface {
 	GetMarket(slug string) (Market, error)
 	GetRecurringMarket(slug string, interval RecurrenceInterval) (Market, error)
 	GetOutcome(marketID, outcomeID string) Outcome
+
+	// Markets returns markets available on this exchange, optionally filtered.
+	// Pass nil filters to get all active markets.
+	Markets(filter *MarketsFilter) ([]Market, error)
 }

--- a/pkg/markets/prediction/types/predict_sdk.go
+++ b/pkg/markets/prediction/types/predict_sdk.go
@@ -14,7 +14,7 @@ type Predict interface {
 	GetRecurringMarketBySlug(slug string, recurrenceInterval predictionconnector.RecurrenceInterval, exchange connector.ExchangeName) (predictionconnector.Market, error)
 	WatchMarket(exchange connector.ExchangeName, market predictionconnector.Market)
 
-	Markets() []predictionconnector.Market
+	Markets(exchange connector.ExchangeName, filter *predictionconnector.MarketsFilter) ([]predictionconnector.Market, error)
 
 	Orderbook(
 		exchange connector.ExchangeName,


### PR DESCRIPTION
- Add MarketsFilter struct to filter by MinVolume and MinLiquidity
- Update Connector.Markets() signature to accept optional filter
- Update Predict.Markets() to pass filters to connector
- Allows SDK to request filtered results from API, reducing network load
- API applies filters server-side instead of client-side filtering
- Enables screener to discover only high-volume, liquid markets