### PR TITLE
fix: BaseStrategy.Emit no silent drop

### DIFF
--- a/pkg/types/strategy/base.go
+++ b/pkg/types/strategy/base.go
@@ -124,13 +124,23 @@ func (b *BaseStrategy) StatusLog() []StrategyStatus {
 	return out
 }
 
-// Emit publishes a signal to the channel. Non-blocking: drops if buffer is full.
+// Emit publishes a signal on the strategy channel.
+// Prefer wisp.Emit for live execution (async execution path).
+// When the strategy context is live, blocks until accepted or ctx canceled —
+// never silently drops. No-op before StartWithRunner (nil channel).
 func (b *BaseStrategy) Emit(signal Signal) {
 	b.marksMu.Lock()
 	b.marks = nil
 	b.marksMu.Unlock()
 
 	if b.signalCh == nil {
+		return
+	}
+	if b.ctx != nil {
+		select {
+		case b.signalCh <- signal:
+		case <-b.ctx.Done():
+		}
 		return
 	}
 	select {

--- a/pkg/types/strategy/base_emit_test.go
+++ b/pkg/types/strategy/base_emit_test.go
@@ -1,0 +1,80 @@
+package strategy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type stubSignal struct{ id uuid.UUID }
+
+func (s stubSignal) GetID() uuid.UUID          { return s.id }
+func (s stubSignal) GetStrategy() StrategyName { return "stub" }
+func (s stubSignal) GetTimestamp() time.Time   { return time.Time{} }
+
+func TestBaseStrategyEmitDoesNotDropWhenConsumerSlow(t *testing.T) {
+	b := NewBaseStrategy(BaseStrategyConfig{Name: "emit-test"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := b.StartWithRunner(ctx, func(ctx context.Context) { <-ctx.Done() }); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = b.Stop(context.Background()) }()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < signalChannelBufferSize+1; i++ {
+			b.Emit(stubSignal{id: uuid.New()})
+		}
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	drained := 0
+	for drained < signalChannelBufferSize+1 {
+		select {
+		case <-b.Signals():
+			drained++
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout waiting for emits; drained=%d", drained)
+		}
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Emit sender did not complete after drain")
+	}
+}
+
+func TestBaseStrategyEmitRespectsCancel(t *testing.T) {
+	b := NewBaseStrategy(BaseStrategyConfig{Name: "emit-cancel"})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := b.StartWithRunner(ctx, func(ctx context.Context) { <-ctx.Done() }); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < signalChannelBufferSize; i++ {
+		b.Emit(stubSignal{id: uuid.New()})
+	}
+
+	blocked := make(chan struct{})
+	go func() {
+		b.Emit(stubSignal{id: uuid.New()})
+		close(blocked)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	_ = b.Stop(context.Background())
+
+	select {
+	case <-blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Emit did not unblock on context cancel")
+	}
+}


### PR DESCRIPTION
## Summary
- `BaseStrategy.Emit` no longer drops on a full buffer when ctx is live.
- Blocks until send or context cancel.
- Tests for drain + cancel.

Live execution should still use `wisp.Emit`.