### PR TITLE
feat: ~/.wisp connectors + remove strategy plugins

### DIFF
--- a/pkg/config/settings/connectors/errors.go
+++ b/pkg/config/settings/connectors/errors.go
@@ -24,7 +24,7 @@ func (ve *ValidationError) Error() string {
 	}
 
 	if ve.NotEnabled {
-		return fmt.Sprintf("exchange '%s' is configured but not enabled in exchanges.yml", ve.Exchange)
+		return fmt.Sprintf("exchange '%s' is configured but not enabled in connector settings (~/.wisp/connectors.yml)", ve.Exchange)
 	}
 
 	if len(ve.Missing) > 0 {
@@ -93,7 +93,7 @@ func (sve *StrategyValidationError) Error() string {
 		if valErr.ExchangeNotFound {
 			msg += "   Not found in SDK registry\n"
 		} else if valErr.NotEnabled {
-			msg += "   Not enabled in exchanges.yml\n"
+			msg += "   Not enabled in connector settings\n"
 		} else if len(valErr.Missing) > 0 {
 			msg += fmt.Sprintf("   Missing credentials: %v\n", valErr.Missing)
 		} else if len(valErr.InvalidFields) > 0 {

--- a/pkg/config/settings/settings.go
+++ b/pkg/config/settings/settings.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/viper"
 	"github.com/wisp-trading/sdk/pkg/types/config"
@@ -11,8 +12,8 @@ import (
 
 // ConfigOptions holds configuration for the settings service
 type ConfigOptions struct {
-	// SettingsPath is the path to the wisp.yml file
-	// If empty, defaults to "wisp.yml" in current directory
+	// SettingsPath is an explicit path to connectors credentials YAML.
+	// Empty means resolve via config.ResolveSettingsPath (default ~/.wisp/connectors.yml).
 	SettingsPath string
 }
 
@@ -23,30 +24,31 @@ type settings struct {
 
 // NewConfiguration creates a new configuration service with the given options
 func NewConfiguration(opts ConfigOptions) config.Configuration {
-	path := opts.SettingsPath
-	if path == "" {
-		path = config.WispConfigurationFileName + ".yml"
-	}
-
+	path := config.ResolveSettingsPath(opts.SettingsPath)
 	return &settings{
 		settingsPath: path,
 	}
 }
 
-// LoadSettings loads the settings from the given path, or default if empty
+// LoadSettings loads the settings from the given path, or resolved default if empty
 func (c *settings) LoadSettings(path string) (*config.Settings, error) {
-	if c.settings != nil {
+	if c.settings != nil && path == "" {
 		return c.settings, nil
 	}
 
-	// Use provided path or fall back to default
 	loadPath := path
 	if loadPath == "" {
 		loadPath = c.settingsPath
 	}
+	if loadPath == "" {
+		loadPath = config.ResolveSettingsPath("")
+	}
 
 	if !c.fileExists(loadPath) {
-		return nil, fmt.Errorf("settings file not found at %s", loadPath)
+		return nil, fmt.Errorf(
+			"settings file not found at %s — add connectors via the wisp CLI Settings UI (saved to ~/.wisp/connectors.yml), or pass an explicit path",
+			loadPath,
+		)
 	}
 
 	v := viper.New()
@@ -64,13 +66,12 @@ func (c *settings) LoadSettings(path string) (*config.Settings, error) {
 	}
 
 	c.settings = &settings
-	c.settingsPath = loadPath // Update path for subsequent operations
+	c.settingsPath = loadPath
 
 	return c.settings, nil
 }
 
-// GetConnectors returns the cached exchange credentials from settings.yml
-// If not loaded yet, it will load the settings config first
+// GetConnectors returns the cached exchange credentials from settings
 func (c *settings) GetConnectors() ([]config.Connector, error) {
 	if c.settings != nil {
 		return c.settings.Connectors, nil
@@ -101,56 +102,48 @@ func (c *settings) GetEnabledConnectors() ([]config.Connector, error) {
 	return enabled, nil
 }
 
-// SaveSettings writes the settings to the wisp.yml file
+// SaveSettings writes the settings file (0600). Ensures parent dir exists.
 func (c *settings) SaveSettings(settings *config.Settings) error {
-	// Use gopkg.in/yaml.v3 for better control over formatting
-	data, err := marshalYAML(settings)
+	dir := filepath.Dir(c.settingsPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("failed to create settings directory: %w", err)
+	}
+
+	data, err := yaml.Marshal(settings)
 	if err != nil {
 		return fmt.Errorf("failed to marshal settings: %w", err)
 	}
 
-	// Write to file
-	if err := os.WriteFile(c.settingsPath, data, 0644); err != nil {
+	if err := os.WriteFile(c.settingsPath, data, 0o600); err != nil {
 		return fmt.Errorf("failed to write settings file: %w", err)
 	}
 
-	// Update cache
 	c.settings = settings
-
 	return nil
 }
 
 // AddConnector adds a new connector to the settings
 func (c *settings) AddConnector(connector config.Connector) error {
-	if c.settings == nil {
-		if _, err := c.LoadSettings(""); err != nil {
-			return err
-		}
+	if err := c.ensureLoadedOrEmpty(); err != nil {
+		return err
 	}
 
-	// Check for duplicate names
 	for _, existing := range c.settings.Connectors {
 		if existing.Name == connector.Name {
 			return fmt.Errorf("connector with name '%s' already exists", connector.Name)
 		}
 	}
 
-	// Add connector
 	c.settings.Connectors = append(c.settings.Connectors, connector)
-
-	// Save
 	return c.SaveSettings(c.settings)
 }
 
 // UpdateConnector updates an existing connector
 func (c *settings) UpdateConnector(connector config.Connector) error {
-	if c.settings == nil {
-		if _, err := c.LoadSettings(""); err != nil {
-			return err
-		}
+	if err := c.ensureLoadedOrEmpty(); err != nil {
+		return err
 	}
 
-	// Find and update connector
 	found := false
 	for i, existing := range c.settings.Connectors {
 		if existing.Name == connector.Name {
@@ -164,19 +157,15 @@ func (c *settings) UpdateConnector(connector config.Connector) error {
 		return fmt.Errorf("connector with name '%s' not found", connector.Name)
 	}
 
-	// Save
 	return c.SaveSettings(c.settings)
 }
 
 // RemoveConnector removes a connector by name
 func (c *settings) RemoveConnector(name string) error {
-	if c.settings == nil {
-		if _, err := c.LoadSettings(""); err != nil {
-			return err
-		}
+	if err := c.ensureLoadedOrEmpty(); err != nil {
+		return err
 	}
 
-	// Filter out the connector
 	filtered := make([]config.Connector, 0, len(c.settings.Connectors))
 	found := false
 	for _, connector := range c.settings.Connectors {
@@ -192,20 +181,15 @@ func (c *settings) RemoveConnector(name string) error {
 	}
 
 	c.settings.Connectors = filtered
-
-	// Save
 	return c.SaveSettings(c.settings)
 }
 
 // EnableConnector toggles the enabled state of a connector
 func (c *settings) EnableConnector(name string, enabled bool) error {
-	if c.settings == nil {
-		if _, err := c.LoadSettings(""); err != nil {
-			return err
-		}
+	if err := c.ensureLoadedOrEmpty(); err != nil {
+		return err
 	}
 
-	// Find and update enabled state
 	found := false
 	for i, connector := range c.settings.Connectors {
 		if connector.Name == name {
@@ -219,17 +203,26 @@ func (c *settings) EnableConnector(name string, enabled bool) error {
 		return fmt.Errorf("connector with name '%s' not found", name)
 	}
 
-	// Save
 	return c.SaveSettings(c.settings)
 }
 
-// FileExists checks if the config file exists
+// ensureLoadedOrEmpty loads settings, or starts empty if the file does not exist yet
+// (first-time CLI Settings use under ~/.wisp).
+func (c *settings) ensureLoadedOrEmpty() error {
+	if c.settings != nil {
+		return nil
+	}
+	if _, err := c.LoadSettings(""); err != nil {
+		if !c.fileExists(c.settingsPath) {
+			c.settings = &config.Settings{Connectors: nil}
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 func (c *settings) fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
-}
-
-// marshalYAML converts Settings to YAML with proper formatting
-func marshalYAML(settings *config.Settings) ([]byte, error) {
-	return yaml.Marshal(settings)
 }

--- a/pkg/config/startup/loader.go
+++ b/pkg/config/startup/loader.go
@@ -32,20 +32,21 @@ func NewStartupConfigLoader(
 	}
 }
 
-// LoadForStrategy loads ALL configuration needed to run a strategy
+// LoadForStrategy loads ALL configuration needed to run a strategy.
+// settingsPath may be empty — resolved to ~/.wisp/connectors.yml (or migration paths).
 func (l *startupConfigLoader) LoadForStrategy(
 	strategyDir string,
-	wispPath string,
+	settingsPath string,
 ) (*config.StartupConfig, error) {
-	// Load wisp settings first (this sets the path for connector service)
-	_, err := l.configuration.LoadSettings(wispPath)
+	resolved := config.ResolveSettingsPath(settingsPath)
+	_, err := l.configuration.LoadSettings(resolved)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load wisp settings: %w", err)
+		return nil, fmt.Errorf("failed to load connector settings: %w", err)
 	}
 
-	l.logger.Info("Loaded wisp settings", "path", wispPath)
+	l.logger.Info("Loaded connector settings", "path", resolved)
 
-	// Load strategy config
+	// Load strategy config (per-strategy; no secrets)
 	configPath := filepath.Join(strategyDir, "config.yml")
 	stratConfig, err := l.strategySvc.Load(configPath)
 	if err != nil {
@@ -54,7 +55,6 @@ func (l *startupConfigLoader) LoadForStrategy(
 
 	l.logger.Info("Loaded strategy config", "name", stratConfig.Name, "exchanges", stratConfig.Exchanges)
 
-	// Get connector configs (now using the loaded settings)
 	connectorConfigs, err := l.connectorSvc.GetConnectorConfigsForStrategy(stratConfig.Exchanges)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connector configs: %w", err)
@@ -62,20 +62,13 @@ func (l *startupConfigLoader) LoadForStrategy(
 
 	l.logger.Info("Loaded connector configs", "count", len(connectorConfigs))
 
-	// Convert assets to instruments
 	assetConfigs := l.convertAssets(stratConfig)
-
 	l.logger.Info("Loaded asset configs", "count", len(assetConfigs))
-
-	// Build plugin path
-	strategyName := filepath.Base(strategyDir)
-	pluginPath := filepath.Join(strategyDir, strategyName+".so")
 
 	return &config.StartupConfig{
 		Strategy:         stratConfig,
 		ConnectorConfigs: connectorConfigs,
 		Assets:           assetConfigs,
-		PluginPath:       pluginPath,
 		StrategyDir:      strategyDir,
 	}, nil
 }

--- a/pkg/modules.go
+++ b/pkg/modules.go
@@ -13,13 +13,15 @@ import (
 	"github.com/wisp-trading/sdk/pkg/markets/price_feeds"
 	"github.com/wisp-trading/sdk/pkg/markets/spot"
 	"github.com/wisp-trading/sdk/pkg/monitoring"
-	"github.com/wisp-trading/sdk/pkg/plugin"
 	"github.com/wisp-trading/sdk/pkg/registry"
 	"github.com/wisp-trading/sdk/pkg/runtime"
 	"github.com/wisp-trading/sdk/pkg/signal"
 	"go.uber.org/fx"
 )
 
+// Module is the full SDK fx graph.
+// Strategy packaging is standalone only (no plugin/.so loader in the graph).
+// pkg/plugin remains available for optional hook plugins if wired explicitly.
 var Module = fx.Options(
 	activity.Module,
 	adapters.Module,
@@ -27,7 +29,6 @@ var Module = fx.Options(
 	config.Module,
 	monitoring.Module,
 	lifecycle.Module,
-	plugin.Module,
 	registry.Module,
 	runtime.Module,
 	signal.Module,

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -12,7 +12,6 @@ import (
 	"github.com/wisp-trading/sdk/pkg/types/connector"
 	"github.com/wisp-trading/sdk/pkg/types/lifecycle"
 	"github.com/wisp-trading/sdk/pkg/types/logging"
-	"github.com/wisp-trading/sdk/pkg/types/plugin"
 	"github.com/wisp-trading/sdk/pkg/types/registry"
 	runtimeTypes "github.com/wisp-trading/sdk/pkg/types/runtime"
 	"github.com/wisp-trading/sdk/pkg/types/strategy"
@@ -22,7 +21,6 @@ import (
 const DefaultStopTimeout = 30 * time.Second
 
 type rt struct {
-	pluginManager     plugin.Manager
 	connectorRegistry registry.ConnectorRegistry
 	strategyRegistry  registry.StrategyRegistry
 	configLoader      configTypes.StartupConfigLoader
@@ -34,7 +32,6 @@ type rt struct {
 }
 
 func NewRuntime(
-	pluginManager plugin.Manager,
 	connectorRegistry registry.ConnectorRegistry,
 	strategyRegistry registry.StrategyRegistry,
 	configLoader configTypes.StartupConfigLoader,
@@ -42,7 +39,6 @@ func NewRuntime(
 	logger logging.ApplicationLogger,
 ) runtimeTypes.Runtime {
 	return &rt{
-		pluginManager:     pluginManager,
 		connectorRegistry: connectorRegistry,
 		strategyRegistry:  strategyRegistry,
 		configLoader:      configLoader,
@@ -51,38 +47,17 @@ func NewRuntime(
 	}
 }
 
-// Start runs a strategy in plugin mode (legacy).
-// Prefer StartStandalone for new strategies.
-func (r *rt) Start(configPath string, wispPath string) error {
-	r.logger.Warn("runtime.Start (plugin mode) is legacy; prefer StartStandalone for new strategies")
-
-	r.ctx, r.cancel = context.WithCancel(context.Background())
-
-	cfg, err := r.configLoader.LoadForStrategy(configPath, wispPath)
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	if _, err := r.initializeConnectors(cfg.ConnectorConfigs); err != nil {
-		return err
-	}
-
-	return r.boot(r.ctx, cfg, runtimeTypes.BootConfig{
-		Mode:         runtimeTypes.BootModePlugin,
-		StrategyPath: cfg.PluginPath,
-	})
-}
-
-// StartStandalone runs a strategy in standalone mode (blessed packaging path).
+// StartStandalone runs a strategy in standalone mode (only packaging path).
 // After a successful return, call Wait so /shutdown and OS signals share one stop path.
+// settingsPath may be empty — uses ResolveSettingsPath (~/.wisp/connectors.yml).
 func (r *rt) StartStandalone(
 	strat strategy.Strategy,
-	configPath string,
-	wispPath string,
+	strategyDir string,
+	settingsPath string,
 ) error {
 	r.ctx, r.cancel = context.WithCancel(context.Background())
 
-	cfg, err := r.configLoader.LoadForStrategy(configPath, wispPath)
+	cfg, err := r.configLoader.LoadForStrategy(strategyDir, settingsPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
@@ -91,14 +66,10 @@ func (r *rt) StartStandalone(
 		return err
 	}
 
-	return r.boot(r.ctx, cfg, runtimeTypes.BootConfig{
-		Mode:     runtimeTypes.BootModeStandalone,
-		Strategy: strat,
-	})
+	return r.boot(r.ctx, cfg, strat)
 }
 
 // Wait blocks until OS signal or remote /shutdown, then stops the runtime.
-// Process hosts should call this after Start/StartStandalone so the process always exits.
 func (r *rt) Wait() error {
 	if r.ctx == nil {
 		return fmt.Errorf("runtime not started")
@@ -130,7 +101,6 @@ func (r *rt) Stop() error {
 
 	if err := r.controller.Stop(stopCtx); err != nil {
 		r.logger.Error(fmt.Sprintf("Failed to stop controller: %v", err))
-		// Still cancel root context so waiters and health loops exit.
 		if r.cancel != nil {
 			r.cancel()
 		}
@@ -145,7 +115,6 @@ func (r *rt) Stop() error {
 	return nil
 }
 
-// initializeConnectors initializes all connectors and marks them ready.
 func (r *rt) initializeConnectors(connectors map[connector.ExchangeName]connector.Config) ([]connector.ExchangeName, error) {
 	names := make([]connector.ExchangeName, 0, len(connectors))
 
@@ -171,30 +140,12 @@ func (r *rt) initializeConnectors(connectors map[connector.ExchangeName]connecto
 	return names, nil
 }
 
-// boot loads the strategy and hands off to the lifecycle controller.
-func (r *rt) boot(ctx context.Context, startupCfg *configTypes.StartupConfig, cfg runtimeTypes.BootConfig) error {
-	r.logger.Info("Booting...", "mode", cfg.Mode)
-
-	var (
-		strat strategy.Strategy
-		err   error
-	)
-
-	switch cfg.Mode {
-	case runtimeTypes.BootModeStandalone:
-		if cfg.Strategy == nil {
-			return fmt.Errorf("no strategy provided in standalone mode")
-		}
-		strat = cfg.Strategy
-
-	default:
-		r.logger.Info("Loading strategy plugin...", "path", cfg.StrategyPath)
-		strat, err = r.pluginManager.LoadStrategyPlugin(cfg.StrategyPath)
-		if err != nil {
-			return fmt.Errorf("failed to load plugin: %w", err)
-		}
+func (r *rt) boot(ctx context.Context, startupCfg *configTypes.StartupConfig, strat strategy.Strategy) error {
+	if strat == nil {
+		return fmt.Errorf("no strategy provided")
 	}
 
+	r.logger.Info("Booting...", "mode", runtimeTypes.BootModeStandalone)
 	r.loadedStrategy = strat
 	r.logger.Info("Strategy loaded", "name", strat.GetName())
 

--- a/pkg/types/config/constants.go
+++ b/pkg/types/config/constants.go
@@ -1,6 +1,87 @@
 package config
 
-const (
-	WispConfigurationFileName = "wisp"
-	StrategiesDirectory       = "strategies"
+import (
+	"os"
+	"path/filepath"
 )
+
+const (
+	// WispConfigurationFileName is the historical project-local basename (wisp.yml).
+	// Prefer ConnectorsFileName under ~/.wisp for credentials.
+	WispConfigurationFileName = "wisp"
+
+	// ConnectorsFileName is the global connector credentials file under WispHomeDir.
+	ConnectorsFileName = "connectors.yml"
+
+	// WispHomeDirName is the directory under the user home for CLI state + credentials.
+	WispHomeDirName = ".wisp"
+
+	// EnvSettingsPath overrides the connectors settings path when set.
+	EnvSettingsPath = "WISP_SETTINGS"
+
+	StrategiesDirectory = "strategies"
+)
+
+// WispHome returns ~/.wisp, creating it if needed.
+func WispHome() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, WispHomeDirName)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// DefaultConnectorsPath is ~/.wisp/connectors.yml (canonical global credentials).
+func DefaultConnectorsPath() (string, error) {
+	dir, err := WispHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ConnectorsFileName), nil
+}
+
+// ResolveSettingsPath picks where connector credentials live.
+//
+// Order:
+//  1. explicit non-empty path (caller / --wisp flag)
+//  2. $WISP_SETTINGS
+//  3. ~/.wisp/connectors.yml if present
+//  4. cwd wisp.yml or exchanges.yml (migration from project-local files)
+//  5. default ~/.wisp/connectors.yml (may not exist yet — create via CLI Settings)
+func ResolveSettingsPath(explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if env := os.Getenv(EnvSettingsPath); env != "" {
+		return env
+	}
+	if def, err := DefaultConnectorsPath(); err == nil {
+		if fileExists(def) {
+			return def
+		}
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		for _, name := range []string{
+			WispConfigurationFileName + ".yml",
+			"exchanges.yml",
+		} {
+			p := filepath.Join(cwd, name)
+			if fileExists(p) {
+				return p
+			}
+		}
+	}
+	if def, err := DefaultConnectorsPath(); err == nil {
+		return def
+	}
+	return ConnectorsFileName
+}
+
+func fileExists(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir()
+}

--- a/pkg/types/config/constants_test.go
+++ b/pkg/types/config/constants_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveSettingsPathExplicit(t *testing.T) {
+	got := ResolveSettingsPath("/tmp/custom.yml")
+	if got != "/tmp/custom.yml" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveSettingsPathEnv(t *testing.T) {
+	t.Setenv(EnvSettingsPath, "/tmp/from-env.yml")
+	got := ResolveSettingsPath("")
+	if got != "/tmp/from-env.yml" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResolveSettingsPathCwdMigration(t *testing.T) {
+	t.Setenv(EnvSettingsPath, "")
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	// Ensure home default does not exist for this process — still may exist on machine.
+	// Create cwd wisp.yml so migration wins when default home file missing.
+	// If ~/.wisp/connectors.yml already exists on the machine, it wins — that's OK.
+	// Force by setting a fake home.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	path := filepath.Join(dir, "wisp.yml")
+	if err := os.WriteFile(path, []byte("connectors: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := ResolveSettingsPath("")
+	abs, _ := filepath.EvalSymlinks(path)
+	gotAbs, _ := filepath.EvalSymlinks(got)
+	if abs == "" {
+		abs, _ = filepath.Abs(path)
+	}
+	if gotAbs == "" {
+		gotAbs, _ = filepath.Abs(got)
+	}
+	if gotAbs != abs {
+		t.Fatalf("expected cwd wisp.yml %q, got %q", abs, gotAbs)
+	}
+}

--- a/pkg/types/config/startup.go
+++ b/pkg/types/config/startup.go
@@ -18,16 +18,15 @@ type StartupConfig struct {
 	// connector types are known.
 	Assets map[connector.ExchangeName][]portfolio.Pair
 
-	// PluginPath is the path to the .so file (for plugin mode)
-	PluginPath string
-
 	// StrategyDir is the directory containing the strategy
 	StrategyDir string
 }
 
 // StartupConfigLoader loads all configuration needed to run a strategy
 type StartupConfigLoader interface {
-	// LoadForStrategy loads strategy config, connector configs, and asset configs
-	// strategyDir: path to the strategy directory containing config.yml
-	LoadForStrategy(strategyDir string, wispPath string) (*StartupConfig, error)
+	// LoadForStrategy loads strategy config.yml + global connector credentials.
+	// strategyDir: directory containing config.yml
+	// settingsPath: optional explicit path; empty uses ResolveSettingsPath
+	// (~/.wisp/connectors.yml, else project-local migration).
+	LoadForStrategy(strategyDir string, settingsPath string) (*StartupConfig, error)
 }

--- a/pkg/types/runtime/runtime.go
+++ b/pkg/types/runtime/runtime.go
@@ -9,39 +9,32 @@ import (
 type BootMode string
 
 const (
-	BootModePlugin     BootMode = "plugin"
+	// BootModeStandalone is the only supported packaging path: strategy owns main.
 	BootModeStandalone BootMode = "standalone"
 )
 
 // BootConfig holds internal configuration for booting
 type BootConfig struct {
 	Mode           BootMode
-	StrategyPath   string
 	Strategy       strategy.Strategy
 	ConnectorNames []connector.ExchangeName
 }
 
 // Runtime is the main entry point for running strategies.
 //
-// Blessed packaging path: StartStandalone + Wait (standalone binary with own main).
-// Plugin mode (Start) is legacy and not recommended for new strategies.
+// Packaging path: StartStandalone + Wait (standalone binary with own main).
+// Plugin / .so loading has been removed.
 type Runtime interface {
-	// Start runs a strategy in plugin mode (legacy).
-	// Prefer StartStandalone for new work. Loads config from configPath
-	// (strategy dir) and wispPath (wisp.yml).
-	Start(configPath string, wispPath string) error
-
-	// StartStandalone runs a strategy in standalone mode (blessed path).
-	// Use this from a strategy binary's main after fx wiring. After StartStandalone
-	// returns successfully, call Wait so /shutdown and OS signals share one stop path.
-	StartStandalone(strategy strategy.Strategy, configPath string, wispPath string) error
+	// StartStandalone runs a strategy in standalone mode.
+	// Use from a strategy binary's main after fx wiring. After success, call Wait
+	// so /shutdown and OS signals share one stop path.
+	// settingsPath may be empty to use ~/.wisp/connectors.yml (or migration paths).
+	StartStandalone(strategy strategy.Strategy, strategyDir string, settingsPath string) error
 
 	// Wait blocks until an OS signal (SIGINT/SIGTERM) or remote /shutdown is
-	// received, then performs a clean Stop and returns. Process hosts should
-	// call Wait after a successful Start/StartStandalone so the process exits.
+	// received, then performs a clean Stop and returns.
 	Wait() error
 
-	// Stop gracefully shuts down. Prefer Wait for the normal process contract;
-	// Stop is still available for tests and custom hosts.
+	// Stop gracefully shuts down. Prefer Wait for the normal process contract.
 	Stop() error
 }


### PR DESCRIPTION
## Summary
- Global credentials: `~/.wisp/connectors.yml` (override: explicit path / `WISP_SETTINGS`; migrate from project-local yml)
- Strategy packaging: **standalone only** — `runtime.Start` / plugin boot removed from default graph

## Test plan
- [x] `go test ./pkg/types/config/ ./pkg/runtime/`