### PR TITLE
fix: harden GetRequiredCredentialFields (existing API)

### DIFF
--- a/pkg/config/settings/connectors/fields_test.go
+++ b/pkg/config/settings/connectors/fields_test.go
@@ -1,0 +1,64 @@
+package connectors
+
+import (
+	"testing"
+
+	"github.com/wisp-trading/sdk/pkg/types/connector"
+)
+
+// sampleConfig mirrors exchange configs: required keys have no omitempty;
+// optional URL/flags use omitempty so zero-value JSON omits them.
+type sampleConfig struct {
+	APIKey    string  `json:"api_key"`
+	APISecret string  `json:"api_secret"`
+	BaseURL   string  `json:"base_url,omitempty"`
+	UseTest   bool    `json:"use_testnet,omitempty"`
+	Slippage  float64 `json:"default_slippage,omitempty"`
+}
+
+func (sampleConfig) ExchangeName() connector.ExchangeName { return "sample" }
+func (sampleConfig) Validate() error                      { return nil }
+
+func TestCredentialFieldsFromConfig_RequiredOnly(t *testing.T) {
+	fields := credentialFieldsFromConfig(sampleConfig{})
+	want := []string{"api_key", "api_secret"}
+	if len(fields) != len(want) {
+		t.Fatalf("fields=%v want %v", fields, want)
+	}
+	for i := range want {
+		if fields[i] != want[i] {
+			t.Fatalf("fields=%v want %v", fields, want)
+		}
+	}
+}
+
+type noisyConfig struct {
+	Key     string `json:"private_key"`
+	Network string `json:"network"`
+	Base    string `json:"base_url"`
+}
+
+func (noisyConfig) ExchangeName() connector.ExchangeName { return "noisy" }
+func (noisyConfig) Validate() error                      { return nil }
+
+func TestCredentialFieldsFromConfig_FiltersNonCredentials(t *testing.T) {
+	got := credentialFieldsFromConfig(noisyConfig{})
+	if len(got) != 1 || got[0] != "private_key" {
+		t.Fatalf("got %v, want [private_key]", got)
+	}
+}
+
+type sortedConfig struct {
+	B string `json:"z_last"`
+	A string `json:"a_first"`
+}
+
+func (sortedConfig) ExchangeName() connector.ExchangeName { return "sorted" }
+func (sortedConfig) Validate() error                      { return nil }
+
+func TestCredentialFieldsFromConfig_Sorted(t *testing.T) {
+	got := credentialFieldsFromConfig(sortedConfig{})
+	if len(got) != 2 || got[0] != "a_first" || got[1] != "z_last" {
+		t.Fatalf("unsorted or wrong: %v", got)
+	}
+}

--- a/pkg/config/settings/connectors/service.go
+++ b/pkg/config/settings/connectors/service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/wisp-trading/sdk/pkg/types/config"
@@ -228,7 +229,24 @@ func (c *connectorService) GetConnectorConfigsForStrategy(exchangeNames []string
 	return connectorConfigs, nil
 }
 
-// GetRequiredCredentialFields returns the credential field names required by an exchange
+// nonCredentialJSONKeys are present on some exchange configs but are not user
+// secrets for the Settings form (URLs, flags, defaults). Discovery still uses
+// NewConfig() JSON; we only filter noise from the form field list.
+var nonCredentialJSONKeys = map[string]struct{}{
+	"network":          {},
+	"use_testnet":      {},
+	"is_testnet":       {},
+	"base_url":         {},
+	"websocket_url":    {},
+	"default_slippage": {},
+	"signature_type":   {},
+	"starknet_rpc":     {},
+}
+
+// GetRequiredCredentialFields returns credential field names for an exchange.
+// Source of truth: connector.NewConfig() zero-value JSON keys (same path as MapToSDKConfig).
+// Fields with json omitempty that are zero are omitted — those are optional.
+// Stable sort for deterministic TUI forms.
 func (c *connectorService) GetRequiredCredentialFields(exchangeName string) []string {
 	conn, exists := c.connectorRegistry.Connector(connector.ExchangeName(exchangeName))
 	if !exists {
@@ -240,6 +258,12 @@ func (c *connectorService) GetRequiredCredentialFields(exchangeName string) []st
 		return []string{}
 	}
 
+	return credentialFieldsFromConfig(cfg)
+}
+
+// credentialFieldsFromConfig extracts form field names from a connector config.
+// Used by GetRequiredCredentialFields; kept package-level for unit tests without a full registry.
+func credentialFieldsFromConfig(cfg connector.Config) []string {
 	configBytes, err := json.Marshal(cfg)
 	if err != nil {
 		return []string{}
@@ -252,10 +276,11 @@ func (c *connectorService) GetRequiredCredentialFields(exchangeName string) []st
 
 	fields := make([]string, 0, len(fieldMap))
 	for key := range fieldMap {
-		if key != "network" && key != "use_testnet" {
-			fields = append(fields, key)
+		if _, skip := nonCredentialJSONKeys[key]; skip {
+			continue
 		}
+		fields = append(fields, key)
 	}
-
+	sort.Strings(fields)
 	return fields
 }

--- a/pkg/config/settings/settings_home_test.go
+++ b/pkg/config/settings/settings_home_test.go
@@ -1,0 +1,61 @@
+package settings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wisp-trading/sdk/pkg/types/config"
+)
+
+func TestSaveAndLoadConnectorsUnderHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(config.EnvSettingsPath, "")
+
+	path, err := config.DefaultConnectorsPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Ensure we write to the resolved home path
+	cfg := NewConfiguration(ConfigOptions{SettingsPath: path}).(*settings)
+
+	err = cfg.AddConnector(config.Connector{
+		Name:    "hyperliquid",
+		Enabled: true,
+		Credentials: map[string]string{
+			"private_key":     "0xabc",
+			"account_address": "0xdef",
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddConnector: %v", err)
+	}
+
+	// Reload from disk
+	cfg2 := NewConfiguration(ConfigOptions{SettingsPath: path}).(*settings)
+	list, err := cfg2.GetConnectors()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].Name != "hyperliquid" {
+		t.Fatalf("list=%v", list)
+	}
+	if list[0].Credentials["private_key"] != "0xabc" {
+		t.Fatalf("credentials not loaded")
+	}
+
+	// File mode should be restrictive
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected 0600-ish perms, got %o", info.Mode().Perm())
+	}
+
+	// Path lives under ~/.wisp
+	if filepath.Base(filepath.Dir(path)) != config.WispHomeDirName {
+		t.Fatalf("path not under .wisp: %s", path)
+	}
+}


### PR DESCRIPTION
## Summary
Improves **existing** `GetRequiredCredentialFields` only — no new schema types.
- Filter URL/flag noise from zero-value NewConfig JSON
- Stable sort
- Tests for field discovery + ~/.wisp settings save/load

Closes #56